### PR TITLE
Fixing null reference exception for an invalid CSS rule.

### DIFF
--- a/StyleMerge.Tests/InlinerTestFixture.cs
+++ b/StyleMerge.Tests/InlinerTestFixture.cs
@@ -104,7 +104,6 @@ namespace StyleMerge.Tests
             Assert.Equal(Outputs.universal_selector_doesnt_apply_to_head.EliminateWhitespace(), processed);
         }
 
-
         [Fact]
         public void InlinerShouldProperlyHandleDoubleQuotesInDeclarations()
         {
@@ -117,6 +116,13 @@ namespace StyleMerge.Tests
         {
             var processed = Inliner.ProcessHtml(Inputs.inliner_should_maintain_important_stats).EliminateWhitespace();
             Assert.Equal(Outputs.inliner_should_maintain_important_declaration.EliminateWhitespace(), processed);
+        }
+
+        [Fact]
+        public void InlinerShouldSkipInvalidCSSDeclarations()
+        {
+            var html = Inliner.ProcessHtml(Inputs.InlinerShouldSkipInvalidCSSDeclarations).EliminateWhitespace();
+            Assert.Equal(Outputs.Expected_InlinerShouldSkipInvalidCSSDeclarations.EliminateWhitespace(), html);
         }
 
         [Fact]

--- a/StyleMerge.Tests/Inputs.Designer.cs
+++ b/StyleMerge.Tests/Inputs.Designer.cs
@@ -351,6 +351,29 @@ namespace StyleMerge.Tests {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &lt;!DOCTYPE html&gt;
+        ///&lt;html&gt;
+        ///    &lt;head&gt;
+        ///        &lt;style&gt;
+        ///            div {
+        ///                color: #000;
+        ///            }
+        ///
+        ///            #foo
+        ///        &lt;/style&gt;
+        ///    &lt;/head&gt;
+        ///&lt;body&gt;
+        ///    &lt;div id=&quot;foo&quot;&gt;&lt;/div&gt;
+        ///&lt;/body&gt;
+        ///&lt;/html&gt;.
+        /// </summary>
+        internal static string InlinerShouldSkipInvalidCSSDeclarations {
+            get {
+                return ResourceManager.GetString("InlinerShouldSkipInvalidCSSDeclarations", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &lt;head&gt;
         ///    &lt;meta charset=&quot;utf-8&quot; /&gt;
         ///    &lt;title&gt;&lt;/title&gt;

--- a/StyleMerge.Tests/Inputs.resx
+++ b/StyleMerge.Tests/Inputs.resx
@@ -169,4 +169,7 @@
   <data name="inliner_should_maintain_important_stats" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\inliner_should_maintain_important_stats.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
+  <data name="InlinerShouldSkipInvalidCSSDeclarations" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Resources\InlinerShouldSkipInvalidCSSDeclarations.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
 </root>

--- a/StyleMerge.Tests/Outputs.Designer.cs
+++ b/StyleMerge.Tests/Outputs.Designer.cs
@@ -193,6 +193,24 @@ namespace StyleMerge.Tests {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &lt;!DOCTYPE html&gt;
+        ///&lt;html&gt;
+        ///    &lt;head&gt;
+        ///        &lt;style&gt;
+        ///            body
+        ///        &lt;/style&gt;
+        ///    &lt;/head&gt;
+        ///&lt;body&gt;
+        ///&lt;/body&gt;
+        ///&lt;/html&gt;.
+        /// </summary>
+        internal static string Expected_InlinerShouldSkipInvalidCSSDeclarations {
+            get {
+                return ResourceManager.GetString("Expected_InlinerShouldSkipInvalidCSSDeclarations", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &lt;html&gt;
         ///&lt;head&gt;
         ///&lt;style type=&quot;text/css&quot;&gt;

--- a/StyleMerge.Tests/Outputs.resx
+++ b/StyleMerge.Tests/Outputs.resx
@@ -139,6 +139,9 @@
   <data name="Expected_InlinerShouldKeepMediaQueryStylesInStyleBlocks" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>resources\expected_inlinershouldkeepmediaquerystylesinstyleblocks.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
+  <data name="Expected_InlinerShouldSkipInvalidCSSDeclarations" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Resources\Expected_InlinerShouldSkipInvalidCSSDeclarations.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
   <data name="Expected_Specificity_Ordering_Test" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>resources\expected_specificity_ordering_test.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>

--- a/StyleMerge.Tests/Resources/Expected_InlinerShouldSkipInvalidCSSDeclarations.html
+++ b/StyleMerge.Tests/Resources/Expected_InlinerShouldSkipInvalidCSSDeclarations.html
@@ -1,0 +1,10 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+
+</head>
+<body>
+    <div style="color: #000" id="foo"></div>
+
+</body>
+</html>

--- a/StyleMerge.Tests/Resources/InlinerShouldSkipInvalidCSSDeclarations.html
+++ b/StyleMerge.Tests/Resources/InlinerShouldSkipInvalidCSSDeclarations.html
@@ -1,0 +1,15 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+<style>
+    div {
+        color: #000;
+    }
+
+    #foo
+</style>
+</head>
+<body>
+    <div id="foo"></div>
+</body>
+</html>

--- a/StyleMerge.Tests/StyleMerge.Tests.csproj
+++ b/StyleMerge.Tests/StyleMerge.Tests.csproj
@@ -112,6 +112,8 @@
     <None Include="Resources\Inliner_Should_Support_PseudoClasses.txt" />
     <None Include="Resources\inliner_should_maintain_important_stats.txt" />
     <None Include="Resources\inliner_should_maintain_important_declaration.txt" />
+    <Content Include="Resources\Expected_InlinerShouldSkipInvalidCSSDeclarations.html" />
+    <Content Include="Resources\InlinerShouldSkipInvalidCSSDeclarations.html" />
     <Content Include="Resources\Specificity_Ordering_Test.html" />
   </ItemGroup>
   <ItemGroup>

--- a/StyleMerge/Inliner.cs
+++ b/StyleMerge/Inliner.cs
@@ -69,7 +69,7 @@ namespace StyleMerge
             {
                 var uninlineable = new List<Tuple<string, StyleDeclaration>>();
 
-                var styleRules = styleSheet.Item2.StyleRules.ToArray();
+                var styleRules = styleSheet.Item2.StyleRules.Where(s => s.Selector != null).ToArray();
                 foreach (var s in styleRules)
                 {
                     var selectors = s.Selector.ToString().Split(',').ToLookup(k => true);


### PR DESCRIPTION
If the inliner encounters an invalid CSS rule a NullReferenceException
would have occurred. The preferred behavior of this project is to just
skip the "bad" rule and continue on. This occurred when a CSS selector was
in a style sheet with no rules declared for it. An example was added to
the test suite under "InlinerShouldSkipInvalidCSSDeclarations.html".